### PR TITLE
feat(docs) Clarify bluetooth profile pairing

### DIFF
--- a/docs/docs/behaviors/bluetooth.md
+++ b/docs/docs/behaviors/bluetooth.md
@@ -9,12 +9,12 @@ The bluetooth behavior allows management of various settings and states related 
 between the keyboard and the host. By default, ZMK supports five "profiles" for selecting which bonded host
 computer/laptop/keyboard should receive the keyboard input; many of the commands here operation on those profiles.
 
-:::note Number of Profiles
-Please note there are only five available Bluetooth profiles by default. If you need to increase the number of available profiles you can set `CONFIG_BT_MAX_CONN` in your `zmk-config` `.conf` file.
-:::
-
 :::note Connection Management
+When pairing to a host device ZMK saves bond information to the selected profile. It will not replace this when you initiate pairing with another device. To pair with a new device select an unused profile with `BT_SEL`, `BT_NXT` or by clearing an existing profile using `BT_CLR`.
+
 A ZMK device may show as "connected" on multiple hosts at the same time. This is working as intended, and only the host associated with the active profile will receive keystrokes.
+
+Please note there are only five available Bluetooth profiles by default. If you need to increase the number of available profiles you can set `CONFIG_BT_MAX_CONN` in your `zmk-config` `.conf` file.
 :::
 
 ## Bluetooth Command Defines


### PR DESCRIPTION
As discussed here;
https://ptb.discord.com/channels/719497620560543766/719909884769992755/876550012153233420

It seems like the bluetooth pairing mechanism ZMK uses isn't always intuitive to new users who may expect an bluetooth device to replace the current bond when it is advertising. However since ZMK does not do this there are frequent questions on the discord and other things like MacOS may be blamed.

I've tried clarifying this behaviour and also included the note about number of profiles to the same note box as I believe this reads slightly nicer than two separate notes relating to the same thing

I'm open to any improvements in phrasing or layout to clarify this further

Cheers!